### PR TITLE
Fix typo in readme instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A Python-based tool for analyzing and extracting patterns and addresses from the
   ```bash
   pip install lief
   pip install capstone
-  pip install colorma
+  pip install colorama
   ```
 
 ---


### PR DESCRIPTION
it's `colorama` not `colorma` lol (it's even spelled correctly above)