### PR TITLE
Fix extract_major.yml

### DIFF
--- a/.github/workflows/extract_major.yml
+++ b/.github/workflows/extract_major.yml
@@ -23,6 +23,7 @@ jobs:
         {
           echo 'RAW_VERSIONS<<EOF'
           curl -s https://spacestation13.github.io/byond-builds/${MAJOR_VERSION}/
+          echo
           echo EOF
         } >> "$GITHUB_ENV"
 


### PR DESCRIPTION
GitHub Actions requires the closing delimiter for a multi-line environment variable (e.g., EOF) to be on a line by itself.
The previous implementation wrote the output of curl directly into $GITHUB_ENV and then appended EOF. However because the new site does not end on a newline `EOF` was becoming the malformed `</html>EOF` failing the match.