### PR TITLE
GitHub pages

### DIFF
--- a/.github/workflows/extract_sigs.yml
+++ b/.github/workflows/extract_sigs.yml
@@ -83,3 +83,141 @@ jobs:
         else
           python byond_tracy_offset_extractor.py "${{ steps.determine_target.outputs.target_file }}"
         fi
+
+    - name: Parse curly-brace signatures to JSON
+      run: |
+        set -euo pipefail
+
+        # Find first 11-address brace line
+        SIG_LINE=$(grep -m1 -E '^\{0x[0-9A-Fa-f]{8}(, 0x[0-9A-Fa-f]{8}){10}\}$' extractor.log || true)
+        if [ -z "$SIG_LINE" ]; then
+          echo "No 11-value signature line found; skipping."
+          exit 0
+        fi
+
+        # -> JSON array of strings
+        SIG_JSON=$(echo "$SIG_LINE" \
+          | sed -e 's/^{/["/' -e 's/}$/"]/ ' -e 's/, /", "/g')
+
+        # Experimental brace line (16 values). If none, null.
+        EXP_LINE=$(awk '/^Experimental Addresses:/{f=1;next} f && /^\{0x/{print;f=0}' extractor.log | head -n1)
+        if [ -n "$EXP_LINE" ]; then
+          EXP_JSON=$(echo "$EXP_LINE" \
+            | sed -e 's/^{/["/' -e 's/}$/"]/ ' -e 's/, /", "/g')
+        else
+          EXP_JSON=null
+        fi
+
+        mkdir -p site
+
+        # Build JSON with jq
+        jq -n \
+          --arg version "$BYOND_VERSION" \
+          --arg platform "${{ matrix.os }}" \
+          --arg build_at "$(date -u +%FT%TZ)" \
+          --argjson addresses "$SIG_JSON" \
+          --argjson experimental "$EXP_JSON" \
+          '{schema:1, version:$version, platform:$platform, addresses:$addresses, experimental:$experimental, build_at:$build_at}' \
+          > "site/${{ matrix.os }}-${BYOND_VERSION}.json"
+
+        echo "Wrote site/${{ matrix.os }}-${BYOND_VERSION}.json"
+
+    - name: Upload page fragment
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: site-fragments
+        path: site/*.json
+
+  publish_pages:
+    needs: extract
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    steps:
+      - name: Download fragments
+        uses: actions/download-artifact@v4
+        with:
+          name: site-fragments
+          path: site
+
+      - name: Build static site files
+        run: |
+          set -euo pipefail
+          mkdir -p public
+
+          # Per-version/per-platform files under public/v/<version>/<platform>.json
+          while IFS= read -r f; do
+            base=$(basename "$f" .json)          # e.g., linux-516.1666
+            plat=${base%%-*}                     # linux
+            ver=${base#*-}                       # 516.1666
+            mkdir -p "public/v/$ver"
+            jq -c '.' "$f" > "public/v/$ver/$plat.json"
+          done < <(find site -name '*.json' -print | sort)
+
+          # data.json = flattened array of every row (stable order by version asc, then platform)
+          jq -s '[ .[] ]' public/v/*/*.json \
+            | jq 'sort_by(.version | split(".") | map(tonumber)) | sort_by(.platform)' \
+            > public/data.json
+
+          # index.json (list of versions + latest pointers)
+          jq -r '.[].version' public/data.json \
+            | sort -t. -k1,1n -k2,2n \
+            | uniq > versions.txt
+
+          latest=$(tail -n1 versions.txt || echo "")
+          latest_linux=$(jq -r '
+            [.[]|select(.platform=="linux")]
+            | max_by(.version|split(".")|map(tonumber))?.version // empty
+          ' public/data.json)
+          latest_windows=$(jq -r '
+            [.[]|select(.platform=="windows")]
+            | max_by(.version|split(".")|map(tonumber))?.version // empty
+          ' public/data.json)
+
+          jq -n --argjson versions "$(jq -R -s 'split("\n")[:-1]' versions.txt)" \
+                --arg any "$latest" --arg linux "$latest_linux" --arg windows "$latest_windows" \
+            '{schema:1, versions:$versions, latest:{any:$any, linux:$linux, windows:$windows}}' \
+            > public/index.json
+
+          # latest aliases
+          [ -n "$latest_linux" ]   && jq -c '.' "public/v/$latest_linux/linux.json"   > public/latest-linux.json  || true
+          [ -n "$latest_windows" ] && jq -c '.' "public/v/$latest_windows/windows.json" > public/latest-windows.json || true
+          if [ -f public/latest-linux.json ]; then cp public/latest-linux.json public/latest.json
+          elif [ -f public/latest-windows.json ]; then cp public/latest-windows.json public/latest.json
+          fi
+
+          # Optional CSV (easy mode for shells/Excel)
+          jq -r '
+            (["version","platform","addresses"] | @csv),
+            (.[] | [ .version, .platform, (.addresses|join(" ")) ] | @csv)
+          ' public/data.json > public/data.csv
+
+          # Minimal index.html (renders data.json in <pre>)
+          cat > public/index.html <<'HTML'
+          <!doctype html><meta charset="utf-8">
+          <title>BYOND Signatures</title>
+          <h1>BYOND Signatures</h1>
+          <p>version + platform → addresses (hex)</p>
+          <pre id="out">Loading…</pre>
+          <script>
+          fetch('data.json').then(r=>r.json()).then(d=>{
+            document.getElementById('out').textContent = JSON.stringify(d, null, 2);
+          }).catch(e=>{
+            document.getElementById('out').textContent = 'Failed to load data.json: ' + e;
+          });
+          </script>
+          HTML
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/extract_sigs.yml
+++ b/.github/workflows/extract_sigs.yml
@@ -24,110 +24,112 @@ jobs:
         os: [windows, linux]
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Set up Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.x'
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install lief
-        pip install capstone
-        pip install colorama
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install lief 
+          pip install capstone
 
-    - name: Set BYOND version
-      run: |
-        BYOND_VERSION="${{ matrix.byond_version }}"
-        # Remove the leading 'v' from the version
-        BYOND_VERSION="${BYOND_VERSION#v}"
-        echo "BYOND_VERSION=$BYOND_VERSION" >> "$GITHUB_ENV"
+      - name: Set BYOND version
+        run: |
+          BYOND_VERSION="${{ matrix.byond_version }}"
+          # Remove the leading 'v' from the version
+          BYOND_VERSION="${BYOND_VERSION#v}"
+          echo "BYOND_VERSION=$BYOND_VERSION" >> "$GITHUB_ENV"
 
-    - name: Download BYOND
-      run: |
-        MAJOR_VERSION=$(echo "$BYOND_VERSION" | cut -d'.' -f1)
-        if [ "${{ matrix.os }}" == "windows" ]; then
+      - name: Download BYOND
+        run: |
+          set -euo pipefail
+          MAJOR_VERSION=$(echo "$BYOND_VERSION" | cut -d'.' -f1)
+          if [ "${{ matrix.os }}" == "windows" ]; then
             DOWNLOAD_URL="https://spacestation13.github.io/byond-builds/${MAJOR_VERSION}/${BYOND_VERSION}_byond.zip"
           else
             DOWNLOAD_URL="https://spacestation13.github.io/byond-builds/${MAJOR_VERSION}/${BYOND_VERSION}_byond_linux.zip"
-        fi
-        wget $DOWNLOAD_URL -O byond.zip
-        unzip byond.zip
+          fi
+          wget $DOWNLOAD_URL -O byond.zip
+          unzip byond.zip
 
-    - name: Determine target file
-      id: determine_target
-      run: |
-        if [ "${{ matrix.os }}" == "windows" ]; then
-          echo "target_file=byond/bin/byondcore.dll" >> "$GITHUB_OUTPUT"
-        else
-          echo "target_file=byond/bin/libbyond.so" >> "$GITHUB_OUTPUT"
-        fi
+      - name: Determine target file
+        id: determine_target
+        run: |
+          if [ "${{ matrix.os }}" == "windows" ]; then
+            echo "target_file=byond/bin/byondcore.dll" >> "$GITHUB_OUTPUT"
+          else
+            echo "target_file=byond/bin/libbyond.so" >> "$GITHUB_OUTPUT"
+          fi
 
-    - name: Determine if old ELF format is needed
-      id: determine_elf
-      run: |
-        MINOR_VERSION=$(echo "$BYOND_VERSION" | cut -d'.' -f2)
-        if [ "${{ matrix.os }}" == "linux" ] && [ "$MINOR_VERSION" -lt 1644 ]; then
-          echo "use_old_elf=true" >> "$GITHUB_OUTPUT"
-        else
-          echo "use_old_elf=false" >> "$GITHUB_OUTPUT"
-        fi
+      - name: Determine if old ELF format is needed
+        id: determine_elf
+        run: |
+          MINOR_VERSION=$(echo "$BYOND_VERSION" | cut -d'.' -f2)
+          if [ "${{ matrix.os }}" == "linux" ] && [ "$MINOR_VERSION" -lt 1644 ]; then
+            echo "use_old_elf=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "use_old_elf=false" >> "$GITHUB_OUTPUT"
+          fi
 
-    - name: Run extraction script
-      run: |
-        if [ "${{ steps.determine_elf.outputs.use_old_elf }}" == "true" ]; then
-          python byond_tracy_offset_extractor.py "${{ steps.determine_target.outputs.target_file }}" --use-old-elf
-        else
-          python byond_tracy_offset_extractor.py "${{ steps.determine_target.outputs.target_file }}"
-        fi
+      - name: Run extraction script
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.determine_elf.outputs.use_old_elf }}" = "true" ]; then
+            python byond_tracy_offset_extractor.py "${{ steps.determine_target.outputs.target_file }}" --use-old-elf | tee extractor.log
+          else
+            python byond_tracy_offset_extractor.py "${{ steps.determine_target.outputs.target_file }}" | tee extractor.log
+          fi
 
-    - name: Parse curly-brace signatures to JSON
-      run: |
-        set -euo pipefail
+      - name: Parse curly-brace signatures to JSON
+        run: |
+          set -euo pipefail
 
-        # Find first 11-address brace line
-        SIG_LINE=$(grep -m1 -E '^\{0x[0-9A-Fa-f]{8}(, 0x[0-9A-Fa-f]{8}){10}\}$' extractor.log || true)
-        if [ -z "$SIG_LINE" ]; then
-          echo "No 11-value signature line found; skipping."
-          exit 0
-        fi
+          # Find the formatted addresses line
+          SIG_LINE=$(grep -m1 -E '^\{0x[0-9A-Fa-f]{8}(, 0x[0-9A-Fa-f]{8}){10}\}$' extractor.log || true)
 
-        # -> JSON array of strings
-        SIG_JSON=$(echo "$SIG_LINE" \
-          | sed -e 's/^{/["/' -e 's/}$/"]/ ' -e 's/, /", "/g')
+          # Experimental Addresses
+          EXP_LINE=$(awk '/^Experimental Addresses:/{f=1;next} f && /^\{0x/{print;f=0}' extractor.log | head -n1)
 
-        # Experimental brace line (16 values). If none, null.
-        EXP_LINE=$(awk '/^Experimental Addresses:/{f=1;next} f && /^\{0x/{print;f=0}' extractor.log | head -n1)
-        if [ -n "$EXP_LINE" ]; then
-          EXP_JSON=$(echo "$EXP_LINE" \
-            | sed -e 's/^{/["/' -e 's/}$/"]/ ' -e 's/, /", "/g')
-        else
-          EXP_JSON=null
-        fi
+          if [ -z "$SIG_LINE" ]; then
+            echo "No address line found in extractor.log"
+            ADDR_JSON='[]'
+          else
+            ADDR_JSON=$(echo "$SIG_LINE" \
+              | sed -e 's/^{/["/' -e 's/}$/"]/ ' -e 's/, /", "/g')
+          fi
 
-        mkdir -p site
+          if [ -n "$EXP_LINE" ]; then
+            EXP_JSON=$(echo "$EXP_LINE" \
+              | sed -e 's/^{/["/' -e 's/}$/"]/ ' -e 's/, /", "/g')
+          else
+            EXP_JSON=null
+          fi
 
-        # Build JSON with jq
-        jq -n \
-          --arg version "$BYOND_VERSION" \
-          --arg platform "${{ matrix.os }}" \
-          --arg build_at "$(date -u +%FT%TZ)" \
-          --argjson addresses "$SIG_JSON" \
-          --argjson experimental "$EXP_JSON" \
-          '{schema:1, version:$version, platform:$platform, addresses:$addresses, experimental:$experimental, build_at:$build_at}' \
-          > "site/${{ matrix.os }}-${BYOND_VERSION}.json"
+          mkdir -p site
+          jq -n \
+            --arg version "$BYOND_VERSION" \
+            --arg platform "${{ matrix.os }}" \
+            --arg build_at "$(date -u +%FT%TZ)" \
+            --argjson addresses "$ADDR_JSON" \
+            --argjson experimental "$EXP_JSON" \
+            '{schema:1, version:$version, platform:$platform, addresses:$addresses, experimental:$experimental, build_at:$build_at}' \
+            > "site/${{ matrix.os }}-${BYOND_VERSION}.json"
 
-        echo "Wrote site/${{ matrix.os }}-${BYOND_VERSION}.json"
+          echo "Wrote site/${{ matrix.os }}-${BYOND_VERSION}.json"
+          ls -l site
 
-    - name: Upload page fragment
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: site-fragments
-        path: site/*.json
+      - name: Upload page fragment
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: site-fragments
+          path: site/*.json
+          if-no-files-found: ignore
 
   publish_pages:
     needs: extract
@@ -151,44 +153,57 @@ jobs:
           mkdir -p public
 
           # Per-version/per-platform files under public/v/<version>/<platform>.json
-          while IFS= read -r f; do
-            base=$(basename "$f" .json)          # e.g., linux-516.1666
-            plat=${base%%-*}                     # linux
-            ver=${base#*-}                       # 516.1666
+          find site -name '*.json' -print | sort | while read -r f; do
+            base=$(basename "$f" .json)   # e.g., linux-516.1666
+            plat=${base%%-*}              # linux
+            ver=${base#*-}                # 516.1666
             mkdir -p "public/v/$ver"
             jq -c '.' "$f" > "public/v/$ver/$plat.json"
-          done < <(find site -name '*.json' -print | sort)
+          done
 
-          # data.json = flattened array of every row (stable order by version asc, then platform)
-          jq -s '[ .[] ]' public/v/*/*.json \
-            | jq 'sort_by(.version | split(".") | map(tonumber)) | sort_by(.platform)' \
-            > public/data.json
+          # data.json = flattened array of every row (stable order: version asc, platform asc)
+          if ls public/v/*/*.json >/dev/null 2>&1; then
+            jq -s '[ .[] ]' public/v/*/*.json \
+              | jq 'sort_by(.version | split(".") | map(tonumber)) | sort_by(.platform)' \
+              > public/data.json
+          else
+            echo '[]' > public/data.json
+          fi
 
           # index.json (list of versions + latest pointers)
           jq -r '.[].version' public/data.json \
             | sort -t. -k1,1n -k2,2n \
-            | uniq > versions.txt
+            | uniq > versions.txt || true
 
-          latest=$(tail -n1 versions.txt || echo "")
+          latest=$(tail -n1 versions.txt 2>/dev/null || echo "")
           latest_linux=$(jq -r '
             [.[]|select(.platform=="linux")]
-            | max_by(.version|split(".")|map(tonumber))?.version // empty
+            | (max_by(.version|split(".")|map(tonumber))?.version // empty)
           ' public/data.json)
           latest_windows=$(jq -r '
             [.[]|select(.platform=="windows")]
-            | max_by(.version|split(".")|map(tonumber))?.version // empty
+            | (max_by(.version|split(".")|map(tonumber))?.version // empty)
           ' public/data.json)
 
-          jq -n --argjson versions "$(jq -R -s 'split("\n")[:-1]' versions.txt)" \
+          jq -n --argjson versions "$(jq -R -s 'split("\n")[:-1]' versions.txt 2>/dev/null || echo '[]')" \
                 --arg any "$latest" --arg linux "$latest_linux" --arg windows "$latest_windows" \
             '{schema:1, versions:$versions, latest:{any:$any, linux:$linux, windows:$windows}}' \
             > public/index.json
 
           # latest aliases
-          [ -n "$latest_linux" ]   && jq -c '.' "public/v/$latest_linux/linux.json"   > public/latest-linux.json  || true
-          [ -n "$latest_windows" ] && jq -c '.' "public/v/$latest_windows/windows.json" > public/latest-windows.json || true
-          if [ -f public/latest-linux.json ]; then cp public/latest-linux.json public/latest.json
-          elif [ -f public/latest-windows.json ]; then cp public/latest-windows.json public/latest.json
+          if [ -n "$latest_linux" ] && [ -f "public/v/$latest_linux/linux.json" ]; then
+            jq -c '.' "public/v/$latest_linux/linux.json" > public/latest-linux.json
+          fi
+          if [ -n "$latest_windows" ] && [ -f "public/v/$latest_windows/windows.json" ]; then
+            jq -c '.' "public/v/$latest_windows/windows.json" > public/latest-windows.json
+          fi
+          if [ -f public/latest-linux.json ]; then
+            cp public/latest-linux.json public/latest.json
+          elif [ -f public/latest-windows.json ]; then
+            cp public/latest-windows.json public/latest.json
+          else
+            # fallback empty latest
+            echo '{}' > public/latest.json
           fi
 
           # Optional CSV (easy mode for shells/Excel)
@@ -197,7 +212,7 @@ jobs:
             (.[] | [ .version, .platform, (.addresses|join(" ")) ] | @csv)
           ' public/data.json > public/data.csv
 
-          # Minimal index.html (renders data.json in <pre>)
+          # Minimal index.html (renders data.json)
           cat > public/index.html <<'HTML'
           <!doctype html><meta charset="utf-8">
           <title>BYOND Signatures</title>

--- a/.github/workflows/extract_sigs.yml
+++ b/.github/workflows/extract_sigs.yml
@@ -127,7 +127,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: site-fragments
+          name: site-fragments-${{ matrix.os }}-${{ env.BYOND_VERSION }}
           path: site/*.json
           if-no-files-found: ignore
 

--- a/.github/workflows/extract_sigs.yml
+++ b/.github/workflows/extract_sigs.yml
@@ -54,7 +54,7 @@ jobs:
           else
             DOWNLOAD_URL="https://spacestation13.github.io/byond-builds/${MAJOR_VERSION}/${BYOND_VERSION}_byond_linux.zip"
           fi
-          wget $DOWNLOAD_URL -O byond.zip
+          wget "$DOWNLOAD_URL" -O byond.zip
           unzip byond.zip
 
       - name: Determine target file
@@ -140,6 +140,9 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Download fragments
         uses: actions/download-artifact@v4
         with:
@@ -214,10 +217,12 @@ jobs:
             (.[] | [ .version, .platform, (.addresses|join(" ")) ] | @csv)
           ' public/data.json > public/data.csv
 
-      - name: Copy site assets
+      - name: Copy site assets (pages/index.html)
         run: |
+          set -euo pipefail
           mkdir -p public
-          cp -R pages/* public/ || true
+          test -f pages/index.html || { echo "ERROR: pages/index.html not found. Commit it to the repo."; exit 1; }
+          cp -R pages/* public/
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/.github/workflows/extract_sigs.yml
+++ b/.github/workflows/extract_sigs.yml
@@ -178,12 +178,14 @@ jobs:
 
           latest=$(tail -n1 versions.txt 2>/dev/null || echo "")
           latest_linux=$(jq -r '
-            [.[]|select(.platform=="linux")]
-            | (max_by(.version|split(".")|map(tonumber))?.version // empty)
+            [.[] | select(.platform=="linux")]
+            | (max_by(.version | split(".") | map(tonumber)) // empty)
+            | if . == null then "" else .version end
           ' public/data.json)
           latest_windows=$(jq -r '
-            [.[]|select(.platform=="windows")]
-            | (max_by(.version|split(".")|map(tonumber))?.version // empty)
+            [.[] | select(.platform=="windows")]
+            | (max_by(.version | split(".") | map(tonumber)) // empty)
+            | if . == null then "" else .version end
           ' public/data.json)
 
           jq -n --argjson versions "$(jq -R -s 'split("\n")[:-1]' versions.txt 2>/dev/null || echo '[]')" \

--- a/.github/workflows/extract_sigs.yml
+++ b/.github/workflows/extract_sigs.yml
@@ -144,7 +144,8 @@ jobs:
       - name: Download fragments
         uses: actions/download-artifact@v4
         with:
-          name: site-fragments
+          pattern: site-fragments-*
+          merge-multiple: true
           path: site
 
       - name: Build static site files

--- a/.github/workflows/extract_sigs.yml
+++ b/.github/workflows/extract_sigs.yml
@@ -110,7 +110,7 @@ jobs:
             EXP_JSON=null
           fi
 
-          mkdir -p site
+          mkdir -p fragments
           jq -n \
             --arg version "$BYOND_VERSION" \
             --arg platform "${{ matrix.os }}" \
@@ -118,17 +118,16 @@ jobs:
             --argjson addresses "$ADDR_JSON" \
             --argjson experimental "$EXP_JSON" \
             '{schema:1, version:$version, platform:$platform, addresses:$addresses, experimental:$experimental, build_at:$build_at}' \
-            > "site/${{ matrix.os }}-${BYOND_VERSION}.json"
+            > "fragments/${{ matrix.os }}-${BYOND_VERSION}.json"
 
-          echo "Wrote site/${{ matrix.os }}-${BYOND_VERSION}.json"
-          ls -l site
+          echo "Wrote fragments/${{ matrix.os }}-${BYOND_VERSION}.json"
+          ls -l fragments
 
       - name: Upload page fragment
-        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: site-fragments-${{ matrix.os }}-${{ env.BYOND_VERSION }}
-          path: site/*.json
+          path: fragments/*.json
           if-no-files-found: ignore
 
   publish_pages:
@@ -146,7 +145,7 @@ jobs:
         with:
           pattern: site-fragments-*
           merge-multiple: true
-          path: site
+          path: fragments
 
       - name: Build static site files
         run: |
@@ -154,7 +153,7 @@ jobs:
           mkdir -p public
 
           # Per-version/per-platform files under public/v/<version>/<platform>.json
-          find site -name '*.json' -print | sort | while read -r f; do
+          find fragments -name '*.json' -print | sort | while read -r f; do
             base=$(basename "$f" .json)   # e.g., linux-516.1666
             plat=${base%%-*}              # linux
             ver=${base#*-}                # 516.1666
@@ -215,21 +214,10 @@ jobs:
             (.[] | [ .version, .platform, (.addresses|join(" ")) ] | @csv)
           ' public/data.json > public/data.csv
 
-          # Minimal index.html (renders data.json)
-          cat > public/index.html <<'HTML'
-          <!doctype html><meta charset="utf-8">
-          <title>BYOND Signatures</title>
-          <h1>BYOND Signatures</h1>
-          <p>version + platform → addresses (hex)</p>
-          <pre id="out">Loading…</pre>
-          <script>
-          fetch('data.json').then(r=>r.json()).then(d=>{
-            document.getElementById('out').textContent = JSON.stringify(d, null, 2);
-          }).catch(e=>{
-            document.getElementById('out').textContent = 'Failed to load data.json: ' + e;
-          });
-          </script>
-          HTML
+      - name: Copy site assets
+        run: |
+          mkdir -p public
+          cp -R pages/* public/ || true
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ You can run the extractor entirely from GitHub using the included Extract Signat
 4. Enter the BYOND version(s) you want to extract, for example: `["515.1590","515.1591"]`
 5. Start the workflow - results will be in the run’s summary output.
 
+### GitHub Pages Output (recommended)
+You can access the latest published results here:  
+**https://sovexe.github.io/byond-tracy-offset-extractor/**
 ### Run Locally
 
 ```bash

--- a/pages/index.html
+++ b/pages/index.html
@@ -1,0 +1,202 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>BYOND Signatures – API Index</title>
+  <style>
+  :root {
+    --bg:#111; --card:#1a1a1a; --border:#2a2a2a; --text:#eaeaea; --muted:#9aa4af; --link:#8ab4ff;
+  }
+  *{box-sizing:border-box}
+  html,body{height:100%}
+  body{margin:0;font:14px/1.5 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Noto Sans";background:var(--bg);color:var(--text)}
+  header{position:sticky;top:0;background:#111;border-bottom:1px solid var(--border);padding:12px 0}
+  .wrap{max-width:900px;margin:0 auto;padding:0 16px}
+  h1{margin:0 0 4px;font-size:18px}
+  .muted{color:var(--muted)}
+  .card{background:var(--card);border:1px solid var(--border);border-radius:8px;padding:12px;margin:12px 0}
+  a{color:var(--link);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code,pre{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace}
+  pre{background:#0b0b0b;border:1px solid var(--border);border-radius:8px;padding:10px;overflow:auto}
+  table{width:100%;border-collapse:collapse}
+  th,td{border-bottom:1px solid var(--border);padding:8px 10px;text-align:left}
+  th{color:var(--muted);font-weight:600}
+  .pill{display:inline-block;border:1px solid var(--border);border-radius:999px;padding:2px 8px;margin-right:6px}
+  .row:hover{background:rgba(255,255,255,.04)}
+  .flex{display:flex;gap:10px;flex-wrap:wrap}
+  .right{margin-left:auto}
+</style>
+</head>
+<body>
+  <header>
+    <div class="wrap">
+      <h1>BYOND Signatures – API & Links</h1>
+      <div class="muted">Static, scraper‑friendly JSON endpoints published by GitHub Actions.</div>
+    </div>
+  </header>
+
+  <main class="wrap">
+    <section class="card">
+      <h3>Primary Endpoints</h3>
+      <ul>
+        <li><a href="data.json">data.json</a> — full dataset (array of items).</li>
+        <li><a href="index.json">index.json</a> — version list + latest pointers.</li>
+        <li><a href="data.csv">data.csv</a> — CSV for quick & dirty consumers.</li>
+        <li><a href="latest.json">latest.json</a> — latest across platforms.</li>
+        <li><a href="latest-linux.json">latest-linux.json</a> — latest Linux.</li>
+        <li><a href="latest-windows.json">latest-windows.json</a> — latest Windows.</li>
+      </ul>
+      <div>
+  <div class="muted" style="margin-bottom:6px">Schema (per item)</div>
+  <pre><code>{
+  "schema": 1,
+  "version": "516.1666",
+  "platform": "linux" | "windows",
+  "addresses": ["0x…", "…"],
+  "experimental": ["0x…"] | null,
+  "build_at": "YYYY-MM-DDTHH:MM:SSZ"
+}</code></pre>
+  <ul class="muted">
+    <li><code>addresses</code> = exactly 11 hex strings with <code>0x</code> prefix.</li>
+    <li><code>experimental</code> may be <code>null</code> or an array of hex strings.</li>
+  </ul>
+</div>
+    </section>
+
+    <section class="card">
+      <div class="flex">
+        <div>
+          <h3 style="margin:0 0 6px">Latest</h3>
+          <div id="latestBadges" class="muted">Loading…</div>
+        </div>
+        <div class="right muted" id="updated">&nbsp;</div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Per‑Version Files</h3>
+      <div class="muted" style="margin-bottom:8px">Links are generated from <code>data.json</code>. Only present platforms are shown.</div>
+      <table>
+        <thead>
+          <tr><th>Version</th><th>Linux</th><th>Windows</th></tr>
+        </thead>
+        <tbody id="versRows"><tr><td colspan="3" class="muted">Loading…</td></tr></tbody>
+      </table>
+    </section>
+
+    <section class="card">
+      <h3>Usage Examples</h3>
+      <p class="muted">Copy‑paste friendly snippets for common tools.</p>
+      <details open>
+        <summary><strong>curl + jq (bash)</strong></summary>
+        <pre><code># Latest Linux curly‑brace line
+curl -sSL ./latest-linux.json \
+ | jq -r '.addresses | "{" + (join(", ")) + "}"'
+
+# Fetch a specific version/platform
+curl -sSL ./v/516.1666/windows.json | jq .
+
+# List all versions
+curl -sSL ./index.json | jq -r '.versions[]'
+</code></pre>
+      </details>
+      <details>
+        <summary><strong>PowerShell</strong></summary>
+        <pre><code>$j = Invoke-RestMethod -Uri "$PSScriptRoot/data.json"
+($j | Where-Object { $_.platform -eq 'linux' } | Sort-Object {
+  $_.version.Split('.') | ForEach-Object {[int]$_}
+} | Select-Object -Last 1).addresses -join ', '
+</code></pre>
+      </details>
+      <details>
+        <summary><strong>JavaScript</strong></summary>
+        <pre><code>const j = await (await fetch('./latest.json')).json();
+console.log('version', j.version, 'platform', j.platform);
+console.log('addresses', '{' + j.addresses.join(', ') + '}');
+</code></pre>
+      </details>
+      <details>
+        <summary><strong>GitHub Actions (shell)</strong></summary>
+        <pre><code>- name: Get latest linux addresses
+  run: |
+    curl -sSL ${{ github.server_url }}/${{ github.repository }}/blob/gh-pages/latest-linux.json?raw=1 \
+      | jq -r '.addresses | "{" + (join(", ")) + "}"'
+</code></pre>
+      </details>
+    </section>
+
+    <section class="card">
+      <h3>Contract</h3>
+      <ul>
+        <li>Stable paths: <code>data.json</code>, <code>index.json</code>, <code>latest*.json</code>, <code>v/&lt;version&gt;/&lt;platform&gt;.json</code>.</li>
+        <li><code>addresses</code> are hex strings with <code>0x</code> prefix; exactly 11 entries.</li>
+        <li><code>experimental</code> may be <code>null</code> or an array of hex strings.</li>
+        <li>Files under <code>v/&lt;version&gt;/</code> are immutable; <code>data.json</code> is append‑only.</li>
+      </ul>
+    </section>
+  </main>
+
+  <script>
+    async function load() {
+      try {
+        const [idxRes, dataRes] = await Promise.all([
+          fetch('index.json'),
+          fetch('data.json')
+        ]);
+        const idx = await idxRes.json();
+        const data = await dataRes.json();
+
+        // Latest badges
+        const lb = document.getElementById('latestBadges');
+        const parts = [];
+        if (idx.latest?.linux) parts.push(`<a class="pill" href="v/${idx.latest.linux}/linux.json">linux: v${idx.latest.linux}</a>`);
+        if (idx.latest?.windows) parts.push(`<a class="pill" href="v/${idx.latest.windows}/windows.json">windows: v${idx.latest.windows}</a>`);
+        if (idx.latest?.any) parts.push(`<a class="pill" href="latest.json">any: v${idx.latest.any}</a>`);
+        lb.innerHTML = parts.length ? parts.join(' ') : '<span class="muted">No latest entries found.</span>';
+
+        // Last updated = max build_at
+        const latestBuild = data.reduce((m,x)=>{
+          const t = Date.parse(x.build_at||'');
+          return isNaN(t)?m:Math.max(m,t);
+        }, 0);
+        if (latestBuild) {
+          const d = new Date(latestBuild).toISOString();
+          document.getElementById('updated').textContent = 'Last updated: ' + d;
+        }
+
+        // Build version → platforms map
+        const map = new Map();
+        for (const row of data) {
+          const set = map.get(row.version) || new Set();
+          set.add(row.platform);
+          map.set(row.version, set);
+        }
+
+        const versions = idx.versions || Array.from(map.keys());
+        // Sort descending by numeric components
+        versions.sort((a,b)=>{
+          const A=a.split('.').map(Number), B=b.split('.').map(Number);
+          return (B[0]-A[0]) || (B[1]-A[1]);
+        });
+
+        const tbody = document.getElementById('versRows');
+        tbody.innerHTML='';
+        for (const v of versions) {
+          const set = map.get(v) || new Set();
+          const tr = document.createElement('tr');
+          tr.className='row';
+          const linux = set.has('linux') ? `<a href="v/${v}/linux.json">linux.json</a>` : '<span class="muted">—</span>';
+          const win   = set.has('windows') ? `<a href="v/${v}/windows.json">windows.json</a>` : '<span class="muted">—</span>';
+          tr.innerHTML = `<td>v${v}</td><td>${linux}</td><td>${win}</td>`;
+          tbody.appendChild(tr);
+        }
+      } catch (e) {
+        document.getElementById('versRows').innerHTML = `<tr><td colspan="3" class="muted">Failed to load: ${e}</td></tr>`;
+      }
+    }
+    load();
+  </script>
+</body>
+</html>

--- a/pages/index.html
+++ b/pages/index.html
@@ -3,11 +3,9 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>BYOND Signatures – API Index</title>
+  <title>BYOND Signatures - API Index</title>
   <style>
-  :root {
-    --bg:#111; --card:#1a1a1a; --border:#2a2a2a; --text:#eaeaea; --muted:#9aa4af; --link:#8ab4ff;
-  }
+  :root { --bg:#111; --card:#1a1a1a; --border:#2a2a2a; --text:#eaeaea; --muted:#9aa4af; --link:#8ab4ff; }
   *{box-sizing:border-box}
   html,body{height:100%}
   body{margin:0;font:14px/1.5 ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,"Noto Sans";background:var(--bg);color:var(--text)}
@@ -27,13 +25,17 @@
   .row:hover{background:rgba(255,255,255,.04)}
   .flex{display:flex;gap:10px;flex-wrap:wrap}
   .right{margin-left:auto}
-</style>
+  .controls{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+  select,button{background:#0b0b0b;border:1px solid var(--border);color:var(--text);padding:6px 8px;border-radius:6px}
+  button{cursor:pointer}
+  .mono{white-space:pre;overflow:auto}
+  </style>
 </head>
 <body>
   <header>
     <div class="wrap">
-      <h1>BYOND Signatures – API & Links</h1>
-      <div class="muted">Static, scraper‑friendly JSON endpoints published by GitHub Actions.</div>
+      <h1>BYOND Signatures - API & Links</h1>
+      <div class="muted">Static, scraper-friendly JSON endpoints published by GitHub Actions.</div>
     </div>
   </header>
 
@@ -44,13 +46,12 @@
         <li><a href="data.json">data.json</a> - full dataset (array of items).</li>
         <li><a href="index.json">index.json</a> - version list + latest pointers.</li>
         <li><a href="data.csv">data.csv</a> - CSV for quick & dirty consumers.</li>
-        <li><a href="latest.json">latest.json</a> - latest across platforms.</li>
         <li><a href="latest-linux.json">latest-linux.json</a> - latest Linux.</li>
         <li><a href="latest-windows.json">latest-windows.json</a> - latest Windows.</li>
       </ul>
       <div>
-  <div class="muted" style="margin-bottom:6px">Schema (per item)</div>
-  <pre><code>{
+        <div class="muted" style="margin-bottom:6px">Schema (per item)</div>
+        <pre><code>{
   "schema": 1,
   "version": "516.1666",
   "platform": "linux" | "windows",
@@ -58,11 +59,7 @@
   "experimental": ["0x…"] | null,
   "build_at": "YYYY-MM-DDTHH:MM:SSZ"
 }</code></pre>
-  <ul class="muted">
-    <li><code>addresses</code> = exactly 11 hex strings with <code>0x</code> prefix.</li>
-    <li><code>experimental</code> may be <code>null</code> or an array of hex strings.</li>
-  </ul>
-</div>
+      </div>
     </section>
 
     <section class="card">
@@ -76,7 +73,38 @@
     </section>
 
     <section class="card">
-      <h3>Per‑Version Files</h3>
+      <h3>View details</h3>
+      <div class="controls">
+        <label>Version
+          <select id="verSelect"></select>
+        </label>
+        <label>Platform
+          <select id="platSelect">
+            <option value="linux">linux</option>
+            <option value="windows">windows</option>
+          </select>
+        </label>
+        <button id="viewBtn">View</button>
+      </div>
+      <div id="detailArea" style="margin-top:10px;display:none">
+        <div class="muted" id="detailMeta"></div>
+        <div style="margin-top:8px">
+          <div class="muted">Curly-brace line</div>
+          <pre class="mono" id="braceLine">{…}</pre>
+        </div>
+        <div style="margin-top:8px" id="expBlock" hidden>
+          <div class="muted">Experimental Addresses</div>
+          <pre class="mono" id="braceLineExp">{…}</pre>
+        </div>
+        <div style="margin-top:8px">
+          <div class="muted">Raw JSON</div>
+          <pre id="rawJson">{}</pre>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <h3>Per-Version Files</h3>
       <div class="muted" style="margin-bottom:8px">Links are generated from <code>data.json</code>. Only present platforms are shown.</div>
       <table>
         <thead>
@@ -88,10 +116,9 @@
 
     <section class="card">
       <h3>Usage Examples</h3>
-      <p class="muted">Copy‑paste friendly snippets for common tools.</p>
       <details open>
         <summary><strong>curl + jq (bash)</strong></summary>
-        <pre><code># Latest Linux curly‑brace line
+        <pre><code># Latest Linux curly-brace line
 curl -sSL ./latest-linux.json \
  | jq -r '.addresses | "{" + (join(", ")) + "}"'
 
@@ -112,33 +139,20 @@ curl -sSL ./index.json | jq -r '.versions[]'
       </details>
       <details>
         <summary><strong>JavaScript</strong></summary>
-        <pre><code>const j = await (await fetch('./latest.json')).json();
+        <pre><code>const j = await (await fetch('./latest-linux.json')).json();
 console.log('version', j.version, 'platform', j.platform);
 console.log('addresses', '{' + j.addresses.join(', ') + '}');
 </code></pre>
       </details>
-      <details>
-        <summary><strong>GitHub Actions (shell)</strong></summary>
-        <pre><code>- name: Get latest linux addresses
-  run: |
-    curl -sSL ${{ github.server_url }}/${{ github.repository }}/blob/gh-pages/latest-linux.json?raw=1 \
-      | jq -r '.addresses | "{" + (join(", ")) + "}"'
-</code></pre>
-      </details>
-    </section>
-
-    <section class="card">
-      <h3>Contract</h3>
-      <ul>
-        <li>Stable paths: <code>data.json</code>, <code>index.json</code>, <code>latest*.json</code>, <code>v/&lt;version&gt;/&lt;platform&gt;.json</code>.</li>
-        <li><code>addresses</code> are hex strings with <code>0x</code> prefix; exactly 11 entries.</li>
-        <li><code>experimental</code> may be <code>null</code> or an array of hex strings.</li>
-        <li>Files under <code>v/&lt;version&gt;/</code> are immutable; <code>data.json</code> is append‑only.</li>
-      </ul>
     </section>
   </main>
 
   <script>
+    let DATA = [];
+    const byVP = new Map(); // key: version|platform -> row
+
+    function brace(arr){ return '{' + (arr||[]).join(', ') + '}'; }
+
     async function load() {
       try {
         const [idxRes, dataRes] = await Promise.all([
@@ -146,41 +160,40 @@ console.log('addresses', '{' + j.addresses.join(', ') + '}');
           fetch('data.json')
         ]);
         const idx = await idxRes.json();
-        const data = await dataRes.json();
+        DATA = await dataRes.json();
 
-        // Latest badges
+        // index maps and selects
+        const verSet = new Set();
+        for (const row of DATA) {
+          verSet.add(row.version);
+          byVP.set(`${row.version}|${row.platform}`, row);
+        }
+        const versions = idx.versions?.slice() || Array.from(verSet);
+        versions.sort((a,b)=>{const A=a.split('.').map(Number),B=b.split('.').map(Number);return (B[0]-A[0])||(B[1]-A[1]);});
+        const verSel = document.getElementById('verSelect');
+        verSel.innerHTML = versions.map(v=>`<option value="${v}">${v}</option>`).join('');
+
+        // default platform: prefer linux if present for latest
+        const platSel = document.getElementById('platSelect');
+
+        // Latest badges (linux/windows only)
         const lb = document.getElementById('latestBadges');
         const parts = [];
         if (idx.latest?.linux) parts.push(`<a class="pill" href="v/${idx.latest.linux}/linux.json">linux: v${idx.latest.linux}</a>`);
         if (idx.latest?.windows) parts.push(`<a class="pill" href="v/${idx.latest.windows}/windows.json">windows: v${idx.latest.windows}</a>`);
-        if (idx.latest?.any) parts.push(`<a class="pill" href="latest.json">any: v${idx.latest.any}</a>`);
         lb.innerHTML = parts.length ? parts.join(' ') : '<span class="muted">No latest entries found.</span>';
 
         // Last updated = max build_at
-        const latestBuild = data.reduce((m,x)=>{
-          const t = Date.parse(x.build_at||'');
-          return isNaN(t)?m:Math.max(m,t);
-        }, 0);
-        if (latestBuild) {
-          const d = new Date(latestBuild).toISOString();
-          document.getElementById('updated').textContent = 'Last updated: ' + d;
-        }
+        const latestBuild = DATA.reduce((m,x)=>{const t=Date.parse(x.build_at||'');return isNaN(t)?m:Math.max(m,t);},0);
+        if (latestBuild) document.getElementById('updated').textContent = 'Last updated: ' + new Date(latestBuild).toISOString();
 
-        // Build version → platforms map
+        // table rows
         const map = new Map();
-        for (const row of data) {
+        for (const row of DATA) {
           const set = map.get(row.version) || new Set();
           set.add(row.platform);
           map.set(row.version, set);
         }
-
-        const versions = idx.versions || Array.from(map.keys());
-        // Sort descending by numeric components
-        versions.sort((a,b)=>{
-          const A=a.split('.').map(Number), B=b.split('.').map(Number);
-          return (B[0]-A[0]) || (B[1]-A[1]);
-        });
-
         const tbody = document.getElementById('versRows');
         tbody.innerHTML='';
         for (const v of versions) {
@@ -192,10 +205,38 @@ console.log('addresses', '{' + j.addresses.join(', ') + '}');
           tr.innerHTML = `<td>v${v}</td><td>${linux}</td><td>${win}</td>`;
           tbody.appendChild(tr);
         }
+
+        // defaults for viewer: latest linux if exists, else first version + available plat
+        let defV = versions[0] || '';
+        let defP = (idx.latest?.linux ? 'linux' : (idx.latest?.windows ? 'windows' : 'linux'));
+        if (!byVP.has(`${defV}|${defP}`)) {
+          defP = byVP.has(`${defV}|windows`) ? 'windows' : 'linux';
+        }
+        verSel.value = defV;
+        platSel.value = defP;
+        renderDetails(defV, defP);
+
+        document.getElementById('viewBtn').addEventListener('click', ()=>{
+          renderDetails(verSel.value, platSel.value);
+        });
       } catch (e) {
         document.getElementById('versRows').innerHTML = `<tr><td colspan="3" class="muted">Failed to load: ${e}</td></tr>`;
       }
     }
+
+    function renderDetails(version, platform){
+      const row = byVP.get(`${version}|${platform}`);
+      const area = document.getElementById('detailArea');
+      if (!row){ area.style.display='none'; return; }
+      area.style.display='block';
+      document.getElementById('detailMeta').textContent = `v${row.version} • ${row.platform} • ${row.build_at||''}`;
+      document.getElementById('braceLine').textContent = brace(row.addresses);
+      const hasExp = Array.isArray(row.experimental) && row.experimental.length>0;
+      document.getElementById('expBlock').hidden = !hasExp;
+      if (hasExp) document.getElementById('braceLineExp').textContent = brace(row.experimental);
+      document.getElementById('rawJson').textContent = JSON.stringify(row, null, 2);
+    }
+
     load();
   </script>
 </body>

--- a/pages/index.html
+++ b/pages/index.html
@@ -41,12 +41,12 @@
     <section class="card">
       <h3>Primary Endpoints</h3>
       <ul>
-        <li><a href="data.json">data.json</a> — full dataset (array of items).</li>
-        <li><a href="index.json">index.json</a> — version list + latest pointers.</li>
-        <li><a href="data.csv">data.csv</a> — CSV for quick & dirty consumers.</li>
-        <li><a href="latest.json">latest.json</a> — latest across platforms.</li>
-        <li><a href="latest-linux.json">latest-linux.json</a> — latest Linux.</li>
-        <li><a href="latest-windows.json">latest-windows.json</a> — latest Windows.</li>
+        <li><a href="data.json">data.json</a> - full dataset (array of items).</li>
+        <li><a href="index.json">index.json</a> - version list + latest pointers.</li>
+        <li><a href="data.csv">data.csv</a> - CSV for quick & dirty consumers.</li>
+        <li><a href="latest.json">latest.json</a> - latest across platforms.</li>
+        <li><a href="latest-linux.json">latest-linux.json</a> - latest Linux.</li>
+        <li><a href="latest-windows.json">latest-windows.json</a> - latest Windows.</li>
       </ul>
       <div>
   <div class="muted" style="margin-bottom:6px">Schema (per item)</div>
@@ -187,8 +187,8 @@ console.log('addresses', '{' + j.addresses.join(', ') + '}');
           const set = map.get(v) || new Set();
           const tr = document.createElement('tr');
           tr.className='row';
-          const linux = set.has('linux') ? `<a href="v/${v}/linux.json">linux.json</a>` : '<span class="muted">—</span>';
-          const win   = set.has('windows') ? `<a href="v/${v}/windows.json">windows.json</a>` : '<span class="muted">—</span>';
+          const linux = set.has('linux') ? `<a href="v/${v}/linux.json">linux.json</a>` : '<span class="muted">-</span>';
+          const win   = set.has('windows') ? `<a href="v/${v}/windows.json">windows.json</a>` : '<span class="muted">-</span>';
           tr.innerHTML = `<td>v${v}</td><td>${linux}</td><td>${win}</td>`;
           tbody.appendChild(tr);
         }

--- a/pages/index.html
+++ b/pages/index.html
@@ -17,7 +17,7 @@
   a{color:var(--link);text-decoration:none}
   a:hover{text-decoration:underline}
   code,pre{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace}
-  pre{background:#0b0b0b;border:1px solid var(--border);border-radius:8px;padding:10px;overflow:auto}
+  pre{background:#0b0b0b;border:1px solid var(--border);border-radius:8px;padding:10px;overflow:auto;margin:0}
   table{width:100%;border-collapse:collapse}
   th,td{border-bottom:1px solid var(--border);padding:8px 10px;text-align:left}
   th{color:var(--muted);font-weight:600}
@@ -26,15 +26,17 @@
   .flex{display:flex;gap:10px;flex-wrap:wrap}
   .right{margin-left:auto}
   .controls{display:flex;gap:8px;align-items:center;flex-wrap:wrap}
-  select,button{background:#0b0b0b;border:1px solid var(--border);color:var(--text);padding:6px 8px;border-radius:6px}
-  button{cursor:pointer}
-  .mono{white-space:pre;overflow:auto}
+  select{background:#0b0b0b;border:1px solid var(--border);color:var(--text);padding:6px 8px;border-radius:6px}
+  .box{margin-top:8px}
+  .boxhdr{display:flex;align-items:center;gap:8px;margin-bottom:6px}
+  .copy{margin-left:auto;background:#0b0b0b;border:1px solid var(--border);color:var(--text);padding:4px 8px;border-radius:6px;cursor:pointer}
+  .copy.ok{border-color:#3fb950;box-shadow:0 0 0 2px rgba(63,185,80,.25) inset}
   </style>
 </head>
 <body>
   <header>
     <div class="wrap">
-      <h1>BYOND Signatures - API & Links</h1>
+      <h1>BYOND Signatures – API & Links</h1>
       <div class="muted">Static, scraper-friendly JSON endpoints published by GitHub Actions.</div>
     </div>
   </header>
@@ -45,13 +47,12 @@
       <ul>
         <li><a href="data.json">data.json</a> - full dataset (array of items).</li>
         <li><a href="index.json">index.json</a> - version list + latest pointers.</li>
-        <li><a href="data.csv">data.csv</a> - CSV for quick & dirty consumers.</li>
+        <li><a href="data.csv">data.csv</a> - CSV formatted.</li>
         <li><a href="latest-linux.json">latest-linux.json</a> - latest Linux.</li>
         <li><a href="latest-windows.json">latest-windows.json</a> - latest Windows.</li>
       </ul>
-      <div>
-        <div class="muted" style="margin-bottom:6px">Schema (per item)</div>
-        <pre><code>{
+      <div class="muted" style="margin-bottom:6px">Schema (per item)</div>
+      <pre><code>{
   "schema": 1,
   "version": "516.1666",
   "platform": "linux" | "windows",
@@ -59,7 +60,6 @@
   "experimental": ["0x…"] | null,
   "build_at": "YYYY-MM-DDTHH:MM:SSZ"
 }</code></pre>
-      </div>
     </section>
 
     <section class="card">
@@ -84,20 +84,32 @@
             <option value="windows">windows</option>
           </select>
         </label>
-        <button id="viewBtn">View</button>
       </div>
+
       <div id="detailArea" style="margin-top:10px;display:none">
         <div class="muted" id="detailMeta"></div>
-        <div style="margin-top:8px">
-          <div class="muted">Curly-brace line</div>
-          <pre class="mono" id="braceLine">{…}</pre>
+
+        <div class="box">
+          <div class="boxhdr">
+            <div class="muted">Addresses</div>
+            <button class="copy" data-copy="#braceLine">Copy</button>
+          </div>
+          <pre id="braceLine">{…}</pre>
         </div>
-        <div style="margin-top:8px" id="expBlock" hidden>
-          <div class="muted">Experimental Addresses</div>
-          <pre class="mono" id="braceLineExp">{…}</pre>
+
+        <div class="box" id="expBlock" hidden>
+          <div class="boxhdr">
+            <div class="muted">Addresses + Experimental Addresses</div>
+            <button class="copy" data-copy="#braceLineExp">Copy</button>
+          </div>
+          <pre id="braceLineExp">{…}</pre>
         </div>
-        <div style="margin-top:8px">
-          <div class="muted">Raw JSON</div>
+
+        <div class="box">
+          <div class="boxhdr">
+            <div class="muted">Raw JSON</div>
+            <button class="copy" data-copy="#rawJson">Copy</button>
+          </div>
           <pre id="rawJson">{}</pre>
         </div>
       </div>
@@ -150,6 +162,7 @@ console.log('addresses', '{' + j.addresses.join(', ') + '}');
   <script>
     let DATA = [];
     const byVP = new Map(); // key: version|platform -> row
+    const $ = (q)=>document.querySelector(q);
 
     function brace(arr){ return '{' + (arr||[]).join(', ') + '}'; }
 
@@ -170,11 +183,10 @@ console.log('addresses', '{' + j.addresses.join(', ') + '}');
         }
         const versions = idx.versions?.slice() || Array.from(verSet);
         versions.sort((a,b)=>{const A=a.split('.').map(Number),B=b.split('.').map(Number);return (B[0]-A[0])||(B[1]-A[1]);});
-        const verSel = document.getElementById('verSelect');
+        const verSel = $('#verSelect');
         verSel.innerHTML = versions.map(v=>`<option value="${v}">${v}</option>`).join('');
 
-        // default platform: prefer linux if present for latest
-        const platSel = document.getElementById('platSelect');
+        const platSel = $('#platSelect');
 
         // Latest badges (linux/windows only)
         const lb = document.getElementById('latestBadges');
@@ -206,19 +218,31 @@ console.log('addresses', '{' + j.addresses.join(', ') + '}');
           tbody.appendChild(tr);
         }
 
-        // defaults for viewer: latest linux if exists, else first version + available plat
+        // defaults for viewer: latest linux if exists, else latest windows, else first
         let defV = versions[0] || '';
-        let defP = (idx.latest?.linux ? 'linux' : (idx.latest?.windows ? 'windows' : 'linux'));
-        if (!byVP.has(`${defV}|${defP}`)) {
-          defP = byVP.has(`${defV}|windows`) ? 'windows' : 'linux';
-        }
+        let defP = idx.latest?.linux ? 'linux' : (idx.latest?.windows ? 'windows' : 'linux');
+        if (!byVP.has(`${defV}|${defP}`)) defP = byVP.has(`${defV}|windows`) ? 'windows' : 'linux';
         verSel.value = defV;
         platSel.value = defP;
         renderDetails(defV, defP);
 
-        document.getElementById('viewBtn').addEventListener('click', ()=>{
-          renderDetails(verSel.value, platSel.value);
+        // Auto-update on select changes
+        verSel.addEventListener('change', ()=>renderDetails(verSel.value, platSel.value));
+        platSel.addEventListener('change', ()=>renderDetails(verSel.value, platSel.value));
+
+        // Clipboard buttons
+        document.querySelectorAll('.copy').forEach(btn=>{
+          btn.addEventListener('click', async ()=>{
+            const target = document.querySelector(btn.dataset.copy);
+            const text = target.textContent;
+            try {
+              await navigator.clipboard.writeText(text);
+              btn.classList.add('ok');
+              setTimeout(()=>btn.classList.remove('ok'), 700);
+            } catch { /* ignore */ }
+          });
         });
+
       } catch (e) {
         document.getElementById('versRows').innerHTML = `<tr><td colspan="3" class="muted">Failed to load: ${e}</td></tr>`;
       }
@@ -230,10 +254,10 @@ console.log('addresses', '{' + j.addresses.join(', ') + '}');
       if (!row){ area.style.display='none'; return; }
       area.style.display='block';
       document.getElementById('detailMeta').textContent = `v${row.version} • ${row.platform} • ${row.build_at||''}`;
-      document.getElementById('braceLine').textContent = brace(row.addresses);
+      document.getElementById('braceLine').textContent = '{' + row.addresses.join(', ') + '}';
       const hasExp = Array.isArray(row.experimental) && row.experimental.length>0;
       document.getElementById('expBlock').hidden = !hasExp;
-      if (hasExp) document.getElementById('braceLineExp').textContent = brace(row.experimental);
+      if (hasExp) document.getElementById('braceLineExp').textContent = '{' + row.experimental.join(', ') + '}';
       document.getElementById('rawJson').textContent = JSON.stringify(row, null, 2);
     }
 


### PR DESCRIPTION
Introduces automated GitHub Pages hosting for extracted BYOND signature data, allowing results to be browsed or fetched directly without running the extractor locally.

- **New GitHub Actions workflow** (`Extract Signatures`):
  - Extracts offsets for one or more BYOND versions (Linux + Windows).
  - Outputs per-platform JSON fragments.
  - Aggregates results into:
    - `/public/v/<version>/<platform>.json`
    - `/public/data.json` - All results
    - `/public/index.json` - Version list + latest pointers
    - `/public/latest.json` - Latest overall platform file
    - `/public/latest-linux.json` / `/public/latest-windows.json` - Platform-specific latest
    - `/public/data.csv` - CSV export
- **Static site publishing:**
  - Copies `/pages/` assets into `/public/` for hosting alongside data files.
  - Automatically deploys via GitHub Pages at:
    - **[https://sovexe.github.io/byond-tracy-offset-extractor/](https://sovexe.github.io/byond-tracy-offset-extractor/)**
- **README updates:**
  - Added direct link to the hosted site for easy access to results.
  - Documented available endpoints.

## Accessing Data
- **Main index:**  
  [https://sovexe.github.io/byond-tracy-offset-extractor/index.json](https://sovexe.github.io/byond-tracy-offset-extractor/index.json)  
- **Latest overall:**  
  [https://sovexe.github.io/byond-tracy-offset-extractor/latest.json](https://sovexe.github.io/byond-tracy-offset-extractor/latest.json)  
- **Latest by platform:**  
  - Linux - [latest-linux.json](https://sovexe.github.io/byond-tracy-offset-extractor/latest-linux.json)  
  - Windows -[latest-windows.json](https://sovexe.github.io/byond-tracy-offset-extractor/latest-windows.json)  
- **Version-specific:**  
  `/v/<version>/<platform>.json`  
  Example:  
  [https://sovexe.github.io/byond-tracy-offset-extractor/v/515.1647/linux.json](https://sovexe.github.io/byond-tracy-offset-extractor/v/515.1647/linux.json)